### PR TITLE
Add Variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
 name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,6 +121,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -246,6 +261,7 @@ version = "1.1.0"
 dependencies = [
  "colored",
  "dirs",
+ "itertools",
  "rand",
  "rustyline",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ rand = "0.8.3"
 
 # For line editing
 rustyline = "8.0.0"
+
+# For fast formatting of multi-line outputs
+itertools = "0.10.0"

--- a/src/lib/errors.rs
+++ b/src/lib/errors.rs
@@ -7,5 +7,5 @@ pub enum Error {
     EmptyStack,
     MismatchingParens,
     Assignment,
-    UnknownVariable(usize)
+    UnknownVariable(usize),
 }

--- a/src/lib/errors.rs
+++ b/src/lib/errors.rs
@@ -7,6 +7,5 @@ pub enum Error {
     EmptyStack,
     MismatchingParens,
     Assignment,
-    AssignmentName,
     UnknownVariable(usize)
 }

--- a/src/lib/errors.rs
+++ b/src/lib/errors.rs
@@ -6,4 +6,7 @@ pub enum Error {
     Operand(OperatorType),
     EmptyStack,
     MismatchingParens,
+    Assignment,
+    AssignmentName,
+    UnknownVariable(usize)
 }

--- a/src/lib/errors.rs
+++ b/src/lib/errors.rs
@@ -6,6 +6,5 @@ pub enum Error {
     Operand(OperatorType),
     EmptyStack,
     MismatchingParens,
-    Assignment,
     UnknownVariable(usize),
 }

--- a/src/lib/eval.rs
+++ b/src/lib/eval.rs
@@ -16,6 +16,9 @@ pub fn eval(tokens: &[Token]) -> Result<f64, Error> {
                 let constant = Constant::by_type(kind);
                 args.push(constant.value);
             }
+            Token::Variable { inner } => {
+                args.push(inner.value)
+            }
             Token::Operator { kind } => {
                 let op = Operator::by_type(kind);
                 let start = match args.len().checked_sub(op.arity) {

--- a/src/lib/eval.rs
+++ b/src/lib/eval.rs
@@ -16,9 +16,7 @@ pub fn eval(tokens: &[Token]) -> Result<f64, Error> {
                 let constant = Constant::by_type(kind);
                 args.push(constant.value);
             }
-            Token::Variable { inner } => {
-                args.push(inner.value)
-            }
+            Token::Variable { inner } => args.push(inner.value),
             Token::Operator { kind } => {
                 let op = Operator::by_type(kind);
                 let start = match args.len().checked_sub(op.arity) {

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -6,15 +6,17 @@ mod rpn;
 mod tokenize;
 pub mod tokens;
 pub mod utils;
+pub(crate) mod variables;
 
 use errors::Error;
 use eval::eval;
 use rpn::rpn;
 use tokenize::tokenize;
 use tokens::Token;
+use variables::Variable;
 
-pub fn doeval(string: &str) -> Result<(f64, Vec<Token>), Error> {
-    let tokens = tokenize(string)?;
+pub fn doeval<'a, 'b>(string: &'a str, vars: &'b [Variable]) -> Result<(f64, Vec<Token<'b>>), Error> {
+    let tokens = tokenize(string, vars)?;
     let rpn = rpn(&tokens)?;
     let result = eval(&rpn)?;
     Ok((result, tokens))

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -16,7 +16,10 @@ use tokenize::tokenize;
 use tokens::Token;
 use variables::Variable;
 
-pub fn doeval<'a, 'b>(string: &'a str, vars: &'b [Variable]) -> Result<(f64, Vec<Token<'b>>), Error> {
+pub fn doeval<'a, 'b>(
+    string: &'a str,
+    vars: &'b [Variable],
+) -> Result<(f64, Vec<Token<'b>>), Error> {
     let tokens = tokenize(string, vars)?;
     let rpn = rpn(&tokens)?;
     let result = eval(&rpn)?;

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -7,7 +7,7 @@ mod rpn;
 mod tokenize;
 pub mod tokens;
 pub mod utils;
-pub(crate) mod variables;
+pub mod variables;
 
 use errors::Error;
 use eval::eval;

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -16,10 +16,7 @@ use tokenize::tokenize;
 use tokens::Token;
 use variables::Variable;
 
-pub fn doeval<'a>(
-    string: &str,
-    vars: &'a [Variable],
-) -> Result<(f64, Vec<Token<'a>>), Error> {
+pub fn doeval<'a>(string: &str, vars: &'a [Variable]) -> Result<(f64, Vec<Token<'a>>), Error> {
     let tokens = tokenize(string, vars)?;
     let rpn = rpn(&tokens)?;
     let result = eval(&rpn)?;

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -16,10 +16,10 @@ use tokenize::tokenize;
 use tokens::Token;
 use variables::Variable;
 
-pub fn doeval<'a, 'b>(
-    string: &'a str,
-    vars: &'b [Variable],
-) -> Result<(f64, Vec<Token<'b>>), Error> {
+pub fn doeval<'a>(
+    string: &str,
+    vars: &'a [Variable],
+) -> Result<(f64, Vec<Token<'a>>), Error> {
     let tokens = tokenize(string, vars)?;
     let rpn = rpn(&tokens)?;
     let result = eval(&rpn)?;

--- a/src/lib/representable.rs
+++ b/src/lib/representable.rs
@@ -3,11 +3,11 @@ pub trait Representable {
 }
 
 pub trait Searchable {
-    fn search<'a, 'b>(&'a self, search: &'b str) -> Option<(&'a Self, usize)>;
+    fn search<'a>(&'a self, search: &str) -> Option<(&'a Self, usize)>;
 }
 
 impl<Repr: Representable> Searchable for Repr {
-    fn search<'a, 'b>(&'a self, search: &'b str) -> Option<(&'a Self, usize)> {
+    fn search<'a>(&'a self, search: &str) -> Option<(&'a Self, usize)> {
         self.repr()
             .iter()
             .find(|repr| search.to_lowercase().starts_with(&repr.to_lowercase()))

--- a/src/lib/rpn.rs
+++ b/src/lib/rpn.rs
@@ -10,7 +10,9 @@ pub fn rpn<'a>(tokens: &'a [Token]) -> Result<Vec<Token<'a>>, Error> {
 
     for token in tokens {
         match token {
-            Token::Number { .. } | Token::Constant { .. } | Token::Variable { .. } => output.push(*token),
+            Token::Number { .. } | Token::Constant { .. } | Token::Variable { .. } => {
+                output.push(*token)
+            }
             Token::Operator { kind } => {
                 let op1 = Operator::by_type(*kind);
                 while !operator_stack.is_empty() {

--- a/src/lib/rpn.rs
+++ b/src/lib/rpn.rs
@@ -4,13 +4,13 @@ use super::{
     tokens::{ParenType, Token},
 };
 
-pub fn rpn(tokens: &[Token]) -> Result<Vec<Token>, Error> {
+pub fn rpn<'a>(tokens: &'a [Token]) -> Result<Vec<Token<'a>>, Error> {
     let mut operator_stack: Vec<Token> = Vec::new();
     let mut output: Vec<Token> = Vec::with_capacity(tokens.len());
 
     for token in tokens {
         match token {
-            Token::Number { .. } | Token::Constant { .. } => output.push(*token),
+            Token::Number { .. } | Token::Constant { .. } | Token::Variable { .. } => output.push(*token),
             Token::Operator { kind } => {
                 let op1 = Operator::by_type(*kind);
                 while !operator_stack.is_empty() {

--- a/src/lib/tokenize.rs
+++ b/src/lib/tokenize.rs
@@ -22,6 +22,8 @@ fn _type(s: &str) -> Result<TokenType, ()> {
         TokenType::Paren
     } else if Constant::is(s) {
         TokenType::Constant
+    } else if Variable::is(s) {
+        TokenType::Variable
     } else {
         return Err(());
     })
@@ -48,17 +50,6 @@ pub fn tokenize<'a, 'b>(string: &'a str, vars: &'b [Variable]) -> Result<Vec<Tok
         // Slice the input from the index until the end
         let slice = utils::slice(string, idx, -0);
 
-        let kind: TokenType = if c == '$' {
-            TokenType::Variable
-        } else {
-            match _type(&slice) {
-                Ok(k) => k,
-                Err(..) => {
-                    return Err(Error::Parsing(idx));
-                }
-            }
-        };
-
         if coeff {
             // No coefficient if the current character is an r-paren
             let is_r_paren = Token::paren_type(c) == Some(ParenType::Right);
@@ -78,6 +69,13 @@ pub fn tokenize<'a, 'b>(string: &'a str, vars: &'b [Variable]) -> Result<Vec<Tok
             }
             coeff = false;
         }
+
+        let kind: TokenType = match _type(&slice) {
+            Ok(k) => k,
+            Err(..) => {
+                return Err(Error::Parsing(idx));
+            }
+        };
 
         match kind {
             TokenType::Operator => {

--- a/src/lib/tokenize.rs
+++ b/src/lib/tokenize.rs
@@ -1,6 +1,6 @@
-use super::{
-    constants::Constant, errors::Error, operators::*, tokens::ParenType, tokens::Token, utils,
-};
+use crate::lib::tokens::get_by_repr;
+
+use super::{constants::{Constant}, errors::Error, operators::*, tokens::ParenType, tokens::Token, utils, variables::Variable};
 
 #[derive(Clone, Debug, PartialEq)]
 enum TokenType {
@@ -26,7 +26,7 @@ fn _type(s: &str) -> Result<TokenType, ()> {
 }
 
 #[allow(clippy::unnecessary_unwrap)]
-pub fn tokenize(string: &str) -> Result<Vec<Token>, Error> {
+pub fn tokenize<'a, 'b>(string: &'a str, vars: &'b [Variable]) -> Result<Vec<Token<'b>>, Error> {
     let mut vec: Vec<Token> = Vec::new();
     let mut explicit_paren = 0;
     let mut idx = 0;
@@ -45,6 +45,12 @@ pub fn tokenize(string: &str) -> Result<Vec<Token>, Error> {
 
         // Slice the input from the index until the end
         let slice = utils::slice(string, idx, -0);
+
+        if c =='$' {
+            println!("{}", slice);
+            let var_idx = idx + 1;
+            get_by_repr(search, list)
+        }
 
         if coeff {
             // No coefficient if the current character is an r-paren

--- a/src/lib/tokenize.rs
+++ b/src/lib/tokenize.rs
@@ -1,4 +1,7 @@
-use super::{constants::{Constant}, errors::Error, operators::*, tokens::ParenType, tokens::Token, utils, variables::Variable};
+use super::{
+    constants::Constant, errors::Error, operators::*, tokens::ParenType, tokens::Token, utils,
+    variables::Variable,
+};
 
 #[derive(Clone, Debug, PartialEq)]
 enum TokenType {
@@ -6,7 +9,7 @@ enum TokenType {
     Operator,
     Paren,
     Constant,
-    Variable
+    Variable,
 }
 
 #[allow(clippy::clippy::iter_nth_zero)]
@@ -47,7 +50,7 @@ pub fn tokenize<'a, 'b>(string: &'a str, vars: &'b [Variable]) -> Result<Vec<Tok
 
         let kind;
 
-        if c =='$' {
+        if c == '$' {
             kind = TokenType::Variable;
         } else {
             kind = match _type(&slice) {
@@ -77,8 +80,6 @@ pub fn tokenize<'a, 'b>(string: &'a str, vars: &'b [Variable]) -> Result<Vec<Tok
             }
             coeff = false;
         }
-
-        
 
         match kind {
             TokenType::Operator => {
@@ -143,10 +144,8 @@ pub fn tokenize<'a, 'b>(string: &'a str, vars: &'b [Variable]) -> Result<Vec<Tok
                     Some(a) => a,
                     None => return Err(Error::UnknownVariable(idx)),
                 };
-                idx += n+1; //+1 to account for '$'
-                vec.push(Token::Variable {
-                    inner: variable,
-                });
+                idx += n + 1; //+1 to account for '$'
+                vec.push(Token::Variable { inner: variable });
                 coeff = true;
                 unary = false;
             }

--- a/src/lib/tokenize.rs
+++ b/src/lib/tokenize.rs
@@ -29,8 +29,8 @@ fn _type(s: &str) -> Result<TokenType, ()> {
     })
 }
 
-#[allow(clippy::unnecessary_unwrap)]
-pub fn tokenize<'a, 'b>(string: &'a str, vars: &'b [Variable]) -> Result<Vec<Token<'b>>, Error> {
+#[allow(clippy::unnecessary_unwrap, clippy::too_many_lines)]
+pub fn tokenize<'a>(string: &str, vars: &'a [Variable]) -> Result<Vec<Token<'a>>, Error> {
     let mut vec: Vec<Token> = Vec::new();
     let mut explicit_paren = 0;
     let mut idx = 0;

--- a/src/lib/tokenize.rs
+++ b/src/lib/tokenize.rs
@@ -49,6 +49,7 @@ pub fn tokenize<'a, 'b>(string: &'a str, vars: &'b [Variable]) -> Result<Vec<Tok
         if c =='$' {
             println!("{}", slice);
             let var_idx = idx + 1;
+            get_by_repr(search, list)
         }
 
         if coeff {

--- a/src/lib/tokenize.rs
+++ b/src/lib/tokenize.rs
@@ -141,7 +141,7 @@ pub fn tokenize<'a, 'b>(string: &'a str, vars: &'b [Variable]) -> Result<Vec<Tok
             TokenType::Variable => {
                 let (variable, n) = match Variable::next_variable(&slice, vars) {
                     Some(a) => a,
-                    None => return Err(Error::Parsing(idx)),
+                    None => return Err(Error::UnknownVariable(idx)),
                 };
                 idx += n+1; //+1 to account for '$'
                 vec.push(Token::Variable {

--- a/src/lib/tokenize.rs
+++ b/src/lib/tokenize.rs
@@ -136,7 +136,8 @@ pub fn tokenize<'a, 'b>(string: &'a str, vars: &'b [Variable]) -> Result<Vec<Tok
                 unary = false;
             }
             TokenType::Variable => {
-                let (variable, n) = match Variable::next_variable(&slice, vars) {
+                let (variable, n) = match Variable::next_variable(&slice[1..], vars) {
+                    // [1..] to ignore the $ prefix
                     Some(a) => a,
                     None => return Err(Error::UnknownVariable(idx)),
                 };

--- a/src/lib/tokenize.rs
+++ b/src/lib/tokenize.rs
@@ -142,7 +142,7 @@ pub fn tokenize<'a, 'b>(string: &'a str, vars: &'b [Variable]) -> Result<Vec<Tok
                     Some(a) => a,
                     None => return Err(Error::UnknownVariable(idx)),
                 };
-                idx += n + 1; //+1 to account for '$'
+                idx += n + 1; // +1 to account for '$'
                 vec.push(Token::Variable { inner: variable });
                 coeff = true;
                 unary = false;

--- a/src/lib/tokenize.rs
+++ b/src/lib/tokenize.rs
@@ -48,15 +48,15 @@ pub fn tokenize<'a, 'b>(string: &'a str, vars: &'b [Variable]) -> Result<Vec<Tok
         // Slice the input from the index until the end
         let slice = utils::slice(string, idx, -0);
 
-        let kind = if c == '$' {
-            TokenType::Variable;
+        let kind: TokenType = if c == '$' {
+            TokenType::Variable
         } else {
             match _type(&slice) {
                 Ok(k) => k,
                 Err(..) => {
                     return Err(Error::Parsing(idx));
                 }
-            };
+            }
         };
 
         if coeff {

--- a/src/lib/tokenize.rs
+++ b/src/lib/tokenize.rs
@@ -49,7 +49,6 @@ pub fn tokenize<'a, 'b>(string: &'a str, vars: &'b [Variable]) -> Result<Vec<Tok
         if c =='$' {
             println!("{}", slice);
             let var_idx = idx + 1;
-            get_by_repr(search, list)
         }
 
         if coeff {

--- a/src/lib/tokenize.rs
+++ b/src/lib/tokenize.rs
@@ -48,18 +48,16 @@ pub fn tokenize<'a, 'b>(string: &'a str, vars: &'b [Variable]) -> Result<Vec<Tok
         // Slice the input from the index until the end
         let slice = utils::slice(string, idx, -0);
 
-        let kind;
-
-        if c == '$' {
-            kind = TokenType::Variable;
+        let kind = if c == '$' {
+            TokenType::Variable;
         } else {
-            kind = match _type(&slice) {
+            match _type(&slice) {
                 Ok(k) => k,
                 Err(..) => {
                     return Err(Error::Parsing(idx));
                 }
             };
-        }
+        };
 
         if coeff {
             // No coefficient if the current character is an r-paren

--- a/src/lib/tokens.rs
+++ b/src/lib/tokens.rs
@@ -3,7 +3,7 @@
 use super::{
     constants::{Constant, ConstantType},
     operators::{Operator, OperatorType},
-    variables::{Variable}
+    variables::Variable,
 };
 
 const NUMBER_CHARACTERS: [char; 11] = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.'];
@@ -21,7 +21,7 @@ pub enum Token<'a> {
     Operator { kind: OperatorType },
     Paren { kind: ParenType },
     Constant { kind: ConstantType },
-    Variable { inner: &'a Variable }
+    Variable { inner: &'a Variable },
 }
 
 impl Token<'_> {
@@ -66,7 +66,7 @@ impl Token<'_> {
                 ParenType::Right => ")".to_string(),
             },
             Self::Constant { kind } => Constant::by_type(*kind).repr[0].to_string(),
-            Self::Variable { inner } => "$".to_owned() + &inner.repr.to_string()
+            Self::Variable { inner } => "$".to_owned() + &inner.repr.to_string(),
         }
     }
 }

--- a/src/lib/tokens.rs
+++ b/src/lib/tokens.rs
@@ -66,7 +66,7 @@ impl Token<'_> {
                 ParenType::Right => ")".to_string(),
             },
             Self::Constant { kind } => Constant::by_type(*kind).repr[0].to_string(),
-            Self::Variable { inner } => "$".to_owned() + &inner.repr.to_string(),
+            Self::Variable { inner } => format!("${}", inner.repr),
         }
     }
 }

--- a/src/lib/tokens.rs
+++ b/src/lib/tokens.rs
@@ -66,7 +66,7 @@ impl Token<'_> {
                 ParenType::Right => ")".to_string(),
             },
             Self::Constant { kind } => Constant::by_type(*kind).repr[0].to_string(),
-            Self::Variable { inner } => inner.repr.to_string()
+            Self::Variable { inner } => "$".to_owned() + &inner.repr.to_string()
         }
     }
 }

--- a/src/lib/tokens.rs
+++ b/src/lib/tokens.rs
@@ -62,8 +62,8 @@ impl Token<'_> {
             Self::Number { value } => value.to_string(),
             Self::Operator { kind } => Operator::by_type(*kind).repr[0].to_string(),
             Self::Paren { kind } => match kind {
-                ParenType::Left => "(".to_string(),
-                ParenType::Right => ")".to_string(),
+                ParenType::Left => '('.to_string(),
+                ParenType::Right => ')'.to_string(),
             },
             Self::Constant { kind } => Constant::by_type(*kind).repr[0].to_string(),
             Self::Variable { inner } => format!("${}", inner.repr),

--- a/src/lib/tokens.rs
+++ b/src/lib/tokens.rs
@@ -3,6 +3,7 @@
 use super::{
     constants::{Constant, ConstantType},
     operators::{Operator, OperatorType},
+    variables::{Variable}
 };
 
 const NUMBER_CHARACTERS: [char; 11] = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.'];
@@ -31,14 +32,15 @@ pub enum ParenType {
 }
 
 #[derive(Clone, Debug, Copy, PartialEq)]
-pub enum Token {
+pub enum Token<'a> {
     Number { value: f64 },
     Operator { kind: OperatorType },
     Paren { kind: ParenType },
     Constant { kind: ConstantType },
+    Variable { inner: &'a Variable }
 }
 
-impl Token {
+impl Token<'_> {
     pub fn paren(c: char) -> Option<(Self, ParenType)> {
         Self::paren_type(c).map(|kind| (Self::Paren { kind }, kind))
     }
@@ -80,6 +82,7 @@ impl Token {
                 ParenType::Right => ")".to_string(),
             },
             Self::Constant { kind } => Constant::by_type(*kind).repr[0].to_string(),
+            Self::Variable { inner } => inner.repr.to_string()
         }
     }
 }

--- a/src/lib/variables.rs
+++ b/src/lib/variables.rs
@@ -1,11 +1,14 @@
 #![allow(clippy::non_ascii_literal)]
 
-use super::{representable::{Searchable, get_by_repr}, utils};
+use super::{
+    representable::{get_by_repr, Searchable},
+    utils,
+};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Variable {
     pub repr: String,
-    pub value: f64
+    pub value: f64,
 }
 
 impl Searchable for Variable {
@@ -21,7 +24,10 @@ impl Searchable for Variable {
 }
 
 impl Variable {
-    pub fn next_variable<'a, 'b>(text: &'a str, vars: &'b [Variable]) -> Option<(&'b Variable, usize)> {
+    pub fn next_variable<'a, 'b>(
+        text: &'a str,
+        vars: &'b [Variable],
+    ) -> Option<(&'b Variable, usize)> {
         get_by_repr(text, vars)
-      }
+    }
 }

--- a/src/lib/variables.rs
+++ b/src/lib/variables.rs
@@ -30,4 +30,7 @@ impl Variable {
     ) -> Option<(&'b Variable, usize)> {
         get_by_repr(text, vars)
     }
+    pub fn is(repr: &str) -> bool {
+        repr.starts_with("$")
+    }
 }

--- a/src/lib/variables.rs
+++ b/src/lib/variables.rs
@@ -1,0 +1,14 @@
+#![allow(clippy::non_ascii_literal)]
+use super::tokens::Representable;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Variable {
+    pub repr: String,
+    pub value: f64
+}
+
+impl Representable for Variable {
+    fn repr(&self) -> String {
+        self.repr
+    }
+}

--- a/src/lib/variables.rs
+++ b/src/lib/variables.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::non_ascii_literal)]
-use super::tokens::Representable;
+
+use super::{representable::{Representable, Searchable, get_by_repr}, utils};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Variable {
@@ -7,8 +8,20 @@ pub struct Variable {
     pub value: f64
 }
 
-impl Representable for Variable {
-    fn repr(&self) -> String {
-        self.repr
+impl Searchable for Variable {
+    fn search<'a, 'b>(&'a self, search: &'b str) -> Option<(&'a Self, usize)> {
+        // Case sensitive
+        let search_str = utils::slice(search, 1, -0); //to ignore $
+        if search_str.starts_with(&self.repr) {
+            Some((self, self.repr.len()))
+        } else {
+            None
+        }
     }
+}
+
+impl Variable {
+    pub fn next_variable<'a, 'b>(text: &'a str, vars: &'b [Variable]) -> Option<(&'b Variable, usize)> {
+        get_by_repr(text, vars)
+      }
 }

--- a/src/lib/variables.rs
+++ b/src/lib/variables.rs
@@ -1,7 +1,4 @@
-use super::{
-    representable::{get_by_repr, Searchable},
-    utils,
-};
+use super::representable::{get_by_repr, Searchable};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Variable {
@@ -12,8 +9,7 @@ pub struct Variable {
 impl Searchable for Variable {
     fn search<'a, 'b>(&'a self, search: &'b str) -> Option<(&'a Self, usize)> {
         // Case sensitive
-        let search_str = utils::slice(search, 1, -0); //to ignore $
-        if search_str.starts_with(&self.repr) {
+        if search.starts_with(&self.repr) {
             Some((self, self.repr.len()))
         } else {
             None

--- a/src/lib/variables.rs
+++ b/src/lib/variables.rs
@@ -19,7 +19,10 @@ impl Searchable for Variable {
 }
 
 impl Variable {
-    /// Searches for the first variable in `vars` that matches the representation given by `text`
+    /// Searches for the first variable in `vars` that matches the representation given by the start of `text`
+    /// * `text` - The string to search. Must start with the name of a variable (not a '$') but can
+    /// be arbitrarily long. Matches are case sensitive.
+    /// * `vars` - A slice of [Variable]s to check for
     pub fn next_variable<'a, 'b>(
         text: &'a str,
         vars: &'b [Variable],

--- a/src/lib/variables.rs
+++ b/src/lib/variables.rs
@@ -23,10 +23,7 @@ impl Variable {
     /// * `text` - The string to search. Must start with the name of a variable (not a '$') but can
     /// be arbitrarily long. Matches are case sensitive.
     /// * `vars` - A slice of [Variable]s to check for
-    pub fn next_variable<'a>(
-        text: &str,
-        vars: &'a [Self],
-    ) -> Option<(&'a Self, usize)> {
+    pub fn next_variable<'a>(text: &str, vars: &'a [Self]) -> Option<(&'a Self, usize)> {
         get_by_repr(text, vars)
     }
 

--- a/src/lib/variables.rs
+++ b/src/lib/variables.rs
@@ -1,6 +1,7 @@
 use super::representable::{get_by_repr, Searchable};
 
 #[derive(Clone, Debug, PartialEq)]
+/// Represents a user definable variable
 pub struct Variable {
     pub repr: String,
     pub value: f64,
@@ -18,12 +19,15 @@ impl Searchable for Variable {
 }
 
 impl Variable {
+    /// Searches for the first variable in `vars` that matches the representation given by `text`
     pub fn next_variable<'a, 'b>(
         text: &'a str,
         vars: &'b [Variable],
     ) -> Option<(&'b Variable, usize)> {
         get_by_repr(text, vars)
     }
+
+    /// Returns whether or not the given representation could reference a valid variable
     pub fn is(repr: &str) -> bool {
         repr.starts_with('$')
     }

--- a/src/lib/variables.rs
+++ b/src/lib/variables.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::non_ascii_literal)]
 
-use super::{representable::{Representable, Searchable, get_by_repr}, utils};
+use super::{representable::{Searchable, get_by_repr}, utils};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Variable {

--- a/src/lib/variables.rs
+++ b/src/lib/variables.rs
@@ -25,6 +25,6 @@ impl Variable {
         get_by_repr(text, vars)
     }
     pub fn is(repr: &str) -> bool {
-        repr.starts_with("$")
+        repr.starts_with('$')
     }
 }

--- a/src/lib/variables.rs
+++ b/src/lib/variables.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::non_ascii_literal)]
-
 use super::{
     representable::{get_by_repr, Searchable},
     utils,

--- a/src/lib/variables.rs
+++ b/src/lib/variables.rs
@@ -8,7 +8,7 @@ pub struct Variable {
 }
 
 impl Searchable for Variable {
-    fn search<'a, 'b>(&'a self, search: &'b str) -> Option<(&'a Self, usize)> {
+    fn search<'a>(&'a self, search: &str) -> Option<(&'a Self, usize)> {
         // Case sensitive
         if search.starts_with(&self.repr) {
             Some((self, self.repr.len()))
@@ -23,10 +23,10 @@ impl Variable {
     /// * `text` - The string to search. Must start with the name of a variable (not a '$') but can
     /// be arbitrarily long. Matches are case sensitive.
     /// * `vars` - A slice of [Variable]s to check for
-    pub fn next_variable<'a, 'b>(
-        text: &'a str,
-        vars: &'b [Variable],
-    ) -> Option<(&'b Variable, usize)> {
+    pub fn next_variable<'a>(
+        text: &str,
+        vars: &'a [Self],
+    ) -> Option<(&'a Self, usize)> {
         get_by_repr(text, vars)
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,6 +102,19 @@ fn assign_var(vars: &mut Vec<Variable>, user_value: f64, user_repr: String) {
     }
 }
 
+fn assign_var_conf_string(token_repr: Vec<Token>, user_repr: &String, user_value: f64) -> String {
+    // Format assignment confirmation
+    let formatted = stringify(&token_repr, color_cli);
+    format!(
+        "[ {}{} {} {} => {} ]",
+        "$".green(),
+        user_repr.green(),
+        "=".cyan(),
+        formatted,
+        format!("{:.3}", user_value).blue()
+    )
+}
+
 fn handle_input(input: &str, vars: &mut Vec<Variable>) -> Result<String, CliError> {
     if input == "$" {
         // Variable list command
@@ -129,20 +142,12 @@ fn handle_input(input: &str, vars: &mut Vec<Variable>) -> Result<String, CliErro
         }
         let (user_value, repr) = result?;
 
-        // Format assignment confirmation
-        let formatted = stringify(&repr, color_cli);
-        let assign_confirmation = format!(
-            "[ {}{} {} {} => {} ]",
-            "$".green(),
-            user_repr.green(),
-            "=".cyan(),
-            formatted,
-            format!("{:.3}", user_value).blue()
-        );
+        // Get printable confirmation string
+        let conf_string = assign_var_conf_string(repr, &user_repr, user_value);
 
         assign_var(vars, user_value, user_repr);
 
-        Ok(assign_confirmation)
+        Ok(conf_string)
     } else {
         // Evaluate as normal
         let result = doeval(&input, &vars);

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,7 @@ fn main() -> ! {
             for v in vars.iter() {
                 println!(
                     "[ {} => {} ]",
-                    ("$".to_owned() + &v.repr).green().bold(),
+                    format!("${}", v.repr).green().bold(),
                     format!("{:.3}", v.value).blue()
                 );
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,12 +32,10 @@ fn main() -> ! {
         editor.load_history(path).ok();
     }
 
-    let mut vars = vec![
-        Variable {
-            repr: String::from("ans"),
-            value: 0.0
-        }
-    ];
+    let mut vars = vec![Variable {
+        repr: String::from("ans"),
+        value: 0.0,
+    }];
 
     loop {
         #[allow(clippy::single_match_else)]
@@ -58,27 +56,26 @@ fn main() -> ! {
         // Add the line to the history
         editor.add_history_entry(&input);
 
-
         match handle_input(&input, &mut vars) {
             Ok(formatted) => println!("{}", formatted),
             Err(error) => handle_errors(error, &input),
         }
-        
     }
 }
 
 fn list_vars_command(vars: &[Variable]) -> String {
     vars.iter()
         .map(|var| {
-          format!(
-            "[ ${} => {} ]",
-            var.repr.green().bold(),
-            format!("{:.3}", var.value).blue()
-          )
-        }).join("\n")
-  }
+            format!(
+                "[ ${} => {} ]",
+                var.repr.green().bold(),
+                format!("{:.3}", var.value).blue()
+            )
+        })
+        .join("\n")
+}
 
-  fn assign_var(vars: &mut Vec<Variable>, user_value: f64, user_repr: String) {
+fn assign_var(vars: &mut Vec<Variable>, user_value: f64, user_repr: String) {
     // Search to see if given representation exists
     let found_var = vars.iter_mut().find(|x| x.repr == user_repr);
     if let Some(found_var) = found_var {
@@ -92,51 +89,50 @@ fn list_vars_command(vars: &[Variable]) -> String {
         };
         vars.push(user_var);
     }
-  }
+}
 
-fn handle_input (input: &str, vars: &mut Vec<Variable>) -> Result<String, Error> {
+fn handle_input(input: &str, vars: &mut Vec<Variable>) -> Result<String, Error> {
     if input == "$" {
         // Variable list command
         Ok(list_vars_command(&vars))
     } else if input.contains("=") {
-            // Variable assignment/reassignment
-            let mut sides: Vec<&str> = input.split('=').collect();
-            sides[0] = sides[0].trim(); // Trim here to remove space between end of variable name and = sign
-            
-            if sides.len() != 2 {
-                // Multiple = signs
-                return Err(Error::Assignment);
-            } else if !sides[0].starts_with("$") {
-                // Assigning without using a $ prefix
-                return Err(Error::Assignment);
-            }
-            
-            let user_repr: String = sides[0][1..].to_string(); // Trim again to remove whitespace between end of variable name and = sign
+        // Variable assignment/reassignment
+        let mut sides: Vec<&str> = input.split('=').collect();
+        sides[0] = sides[0].trim(); // Trim here to remove space between end of variable name and = sign
 
-            // Get value for variable
-            let result = doeval(sides[1], vars);
-            if let Err(Error::Parsing(idx)) = result {
-                return Err(Error::Parsing(idx + sides[0].len() + 1));
-                // Offset is added so that highlighting can be added to expressions that come after an '=' during assignment
-            } 
-            let (user_value, repr) = result?;
-
-            // Format assignment confirmation
-            let formatted = stringify(&repr, color_cli);
-            let assign_confirmation = format!(
-                "[ {}{} {} {} => {} ]",
-                "$".green(),
-                user_repr.green(),
-                "=".cyan(),
-                formatted,
-                format!("{:.3}", user_value).blue()
-            );
-
-            assign_var(vars, user_value, user_repr);
-            
-            Ok(assign_confirmation)
+        if sides.len() != 2 {
+            // Multiple = signs
+            return Err(Error::Assignment);
+        } else if !sides[0].starts_with("$") {
+            // Assigning without using a $ prefix
+            return Err(Error::Assignment);
         }
-    else {
+
+        let user_repr: String = sides[0][1..].to_string(); // Trim again to remove whitespace between end of variable name and = sign
+
+        // Get value for variable
+        let result = doeval(sides[1], vars);
+        if let Err(Error::Parsing(idx)) = result {
+            return Err(Error::Parsing(idx + sides[0].len() + 1));
+            // Offset is added so that highlighting can be added to expressions that come after an '=' during assignment
+        }
+        let (user_value, repr) = result?;
+
+        // Format assignment confirmation
+        let formatted = stringify(&repr, color_cli);
+        let assign_confirmation = format!(
+            "[ {}{} {} {} => {} ]",
+            "$".green(),
+            user_repr.green(),
+            "=".cyan(),
+            formatted,
+            format!("{:.3}", user_value).blue()
+        );
+
+        assign_var(vars, user_value, user_repr);
+
+        Ok(assign_confirmation)
+    } else {
         // Evaluate as normal
         let result = doeval(&input, &vars);
         if let Err(Error::Parsing(idx)) = result {
@@ -165,13 +161,7 @@ fn handle_errors(error: Error, input: &str) {
                 "Couldn't parse the token at index [{}]\n{}{}{}\n{}{}",
                 idx.to_string().red(),
                 first,
-                input
-                    .chars()
-                    .nth(idx)
-                    .unwrap()
-                    .to_string()
-                    .on_red()
-                    .white(),
+                input.chars().nth(idx).unwrap().to_string().on_red().white(),
                 utils::slice(&input, idx + 1, -0),
                 "~".repeat(idx).red().bold(),
                 "^".red()
@@ -202,13 +192,7 @@ fn handle_errors(error: Error, input: &str) {
                 "Unknown variable at index [{}]\n{}{}{}\n{}{}",
                 idx.to_string().red(),
                 first,
-                input
-                    .chars()
-                    .nth(idx)
-                    .unwrap()
-                    .to_string()
-                    .on_red()
-                    .white(),
+                input.chars().nth(idx).unwrap().to_string().on_red().white(),
                 utils::slice(&input, idx + 1, -0),
                 "~".repeat(idx).red().bold(),
                 "^".red()
@@ -593,11 +577,11 @@ mod tests {
         let test_vars = vec![
             Variable {
                 repr: String::from("v"),
-                value: 5.0
+                value: 5.0,
             },
             Variable {
                 repr: String::from("pi"),
-                value: 7.0
+                value: 7.0,
             },
         ];
 
@@ -665,15 +649,12 @@ mod tests {
             assert!(same(result, *c), "Checking evaluation of [{}]", a);
             assert_eq!(stringify(&tokens, |a, _| a.to_string()), *b);
         });
-
     }
-    
+
     #[test]
     fn fail_vars() {
-        vec![
-            ("3 + $a", Error::UnknownVariable(4)),
-        ]
-        .iter()
-        .for_each(|(a, b)| assert_eq!(doeval(a, &[]).unwrap_err(), *b));
+        vec![("3 + $a", Error::UnknownVariable(4))]
+            .iter()
+            .for_each(|(a, b)| assert_eq!(doeval(a, &[]).unwrap_err(), *b));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,13 @@ fn main() -> ! {
             continue;
         }
 
+        if input == "$" {
+            for v in vars.iter() {
+                println!("[ {} => {} ]", v.repr.green().bold(), v.value.to_string().blue());
+            }
+            continue;
+        }
+
         let (x, repr) = match doeval(&input, &vars) {
             Ok((a, b)) => (a, b),
             Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,9 +110,8 @@ fn assign_var_command(input: &str, vars: &mut Vec<Variable>) -> Result<String, C
 
     // Get printable confirmation string
     let conf_string = format!(
-        "[ {}{} {} {} => {} ]",
-        "$".green(),
-        user_repr.green(),
+        "[ ${} {} {} => {} ]",
+        user_repr.green().bold(),
         "=".cyan(),
         stringify(&repr, color_cli),
         format!("{:.3}", user_value).blue()

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ fn main() -> ! {
 
         if input == "$" {
             for v in vars.iter() {
-                println!("[ {} => {} ]", v.repr.green().bold(), format!("{:.3}", v.value).blue());
+                println!("[ {} => {} ]", ("$".to_owned() + &v.repr).green().bold(), format!("{:.3}", v.value).blue());
             }
             // Add the line to the history
             editor.add_history_entry(input);
@@ -67,8 +67,12 @@ fn main() -> ! {
                 handle_errors(Error::Assignment, input, 0);
                 continue;
             }
+            else if !sides[0].trim().starts_with("$") {
+                handle_errors(Error::Assignment, input, 0);
+                continue;
+            }
             
-            let user_repr: String = sides[0].trim().to_string();
+            let user_repr: String = sides[0].trim()[1..].to_string();
             let (user_value, repr) = match doeval(&sides[1], &vars) {
                 Ok((a, b)) => (a, b),
                 Err(e) => {
@@ -79,7 +83,7 @@ fn main() -> ! {
 
             //Print assignment confimation
             let formatted = stringify(&repr, color_cli);
-            println!("[ {} {} {} => {} ]",user_repr.green(), "=".cyan(), formatted, format!("{:.3}", user_value).blue());
+            println!("[ {}{} {} {} => {} ]", "$".green(), user_repr.green(), "=".cyan(), formatted, format!("{:.3}", user_value).blue());
 
             let found_var = vars.iter_mut().find(|x| x.repr == user_repr);
             if let Some(found_var) = found_var {

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,7 +95,7 @@ fn handle_input(input: &str, vars: &mut Vec<Variable>) -> Result<String, Error> 
     if input == "$" {
         // Variable list command
         Ok(list_vars_command(&vars))
-    } else if input.contains("=") {
+    } else if input.contains('=') {
         // Variable assignment/reassignment
         let mut sides: Vec<&str> = input.split('=').collect();
         sides[0] = sides[0].trim(); // Trim here to remove space between end of variable name and = sign
@@ -103,7 +103,7 @@ fn handle_input(input: &str, vars: &mut Vec<Variable>) -> Result<String, Error> 
         if sides.len() != 2 {
             // Multiple = signs
             return Err(Error::Assignment);
-        } else if !sides[0].starts_with("$") {
+        } else if !sides[0].starts_with('$') {
             // Assigning without using a $ prefix
             return Err(Error::Assignment);
         }
@@ -260,7 +260,7 @@ where
                 } else if !(is_r_paren || is_op) {
                     ", ".to_string()
                 } else if is_op && !is_pow {
-                    " ".to_string()
+                    ' '.to_string()
                 } else {
                     "".to_string()
                 };
@@ -576,7 +576,7 @@ mod tests {
     fn test_vars() {
         let test_vars = vec![
             Variable {
-                repr: String::from("v"),
+                repr: String::from('v'),
                 value: 5.0,
             },
             Variable {

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,8 @@ fn main() -> ! {
             for v in vars.iter() {
                 println!("[ {} => {} ]", v.repr.green().bold(), v.value.to_string().blue());
             }
+            // Add the line to the history
+            editor.add_history_entry(input);
             continue;
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,35 +87,36 @@ fn list_vars_command(vars: &[Variable]) -> String {
 }
 
 fn assign_var_command(input: &str, vars: &mut Vec<Variable>) -> Result<String, CliError> {
-     // Variable assignment/reassignment
+    // Variable assignment/reassignment
 
-     let sides: Vec<&str> = input.split('=').collect();
-     let trimmed_left = sides[0].trim(); // Trim here to remove space between end of variable name and = sign
+    let sides: Vec<&str> = input.split('=').collect();
+    let trimmed_left = sides[0].trim(); // Trim here to remove space between end of variable name and = sign
 
-     if sides.len() != 2 {
-         // Multiple = signs
-         return Err(CliError::Assignment);
-     } else if !trimmed_left.starts_with('$') {
-         // Assigning without using a $ prefix
-         return Err(CliError::Assignment);
-     }
+    if sides.len() != 2 {
+        // Multiple = signs
+        return Err(CliError::Assignment);
+    } else if !trimmed_left.starts_with('$') {
+        // Assigning without using a $ prefix
+        return Err(CliError::Assignment);
+    }
 
-     let user_repr: String = trimmed_left[1..].to_string(); // Trim again to remove whitespace between end of variable name and = sign
+    let user_repr: String = trimmed_left[1..].to_string(); // Trim again to remove whitespace between end of variable name and = sign
 
-     // Get value for variable
-     let result = doeval(sides[1], vars);
-     if let Err(Error::Parsing(idx)) = result {
-         return Err(CliError::Library(Error::Parsing(idx + sides[0].len() + 1))); // Length of untrimmed lefthand side
-         // Offset is added so that highlighting can be added to expressions that come after an '=' during assignment
-     }
-     let (user_value, repr) = result?;
+    // Get value for variable
+    let result = doeval(sides[1], vars);
+    if let Err(Error::Parsing(idx)) = result {
+        return Err(CliError::Library(Error::Parsing(idx + sides[0].len() + 1)));
+        // Length of untrimmed lefthand side
+        // Offset is added so that highlighting can be added to expressions that come after an '=' during assignment
+    }
+    let (user_value, repr) = result?;
 
-     // Get printable confirmation string
-     let conf_string = assign_var_conf_string(repr, &user_repr, user_value);
+    // Get printable confirmation string
+    let conf_string = assign_var_conf_string(repr, &user_repr, user_value);
 
-     assign_var(vars, user_value, user_repr);
+    assign_var(vars, user_value, user_repr);
 
-     Ok(conf_string)
+    Ok(conf_string)
 }
 
 fn assign_var(vars: &mut Vec<Variable>, user_value: f64, user_repr: String) {
@@ -153,7 +154,7 @@ fn handle_input(input: &str, vars: &mut Vec<Variable>) -> Result<String, CliErro
         Ok(list_vars_command(&vars))
     } else if input.contains('=') {
         // Assign / Reassign variable command
-        assign_var_command(&input, vars) 
+        assign_var_command(&input, vars)
     } else {
         // Evaluate as normal
         let result = doeval(&input, &vars);
@@ -171,7 +172,7 @@ fn handle_input(input: &str, vars: &mut Vec<Variable>) -> Result<String, CliErro
     }
 }
 
-fn make_highlighted_error(msg: &str, input_str: &str,  idx:usize) -> String{
+fn make_highlighted_error(msg: &str, input_str: &str, idx: usize) -> String {
     let first = if idx > 0 {
         utils::slice(&input_str, 0, (idx) as i64)
     } else {
@@ -182,7 +183,13 @@ fn make_highlighted_error(msg: &str, input_str: &str,  idx:usize) -> String{
         msg,
         idx.to_string().red(),
         first,
-        input_str.chars().nth(idx).unwrap().to_string().on_red().white(),
+        input_str
+            .chars()
+            .nth(idx)
+            .unwrap()
+            .to_string()
+            .on_red()
+            .white(),
         utils::slice(&input_str, idx + 1, -0),
         "~".repeat(idx).red().bold(),
         "^".red()
@@ -196,7 +203,10 @@ fn handle_errors(error: CliError, input: &str) {
         }
         CliError::Library(inner) => match inner {
             Error::Parsing(idx) => {
-                println!("{}", make_highlighted_error("Couldn't parse the token at index", input, idx));
+                println!(
+                    "{}",
+                    make_highlighted_error("Couldn't parse the token at index", input, idx)
+                );
             }
             Error::Operand(kind) => {
                 println!(
@@ -211,7 +221,10 @@ fn handle_errors(error: CliError, input: &str) {
                 println!("Couldn't evaluate. Mismatched parens.");
             }
             Error::UnknownVariable(idx) => {
-                println!("{}", make_highlighted_error("Unknown variable at index", input, idx+1)); // +1 to highlight first letter of variable and not the $
+                println!(
+                    "{}",
+                    make_highlighted_error("Unknown variable at index", input, idx + 1)
+                ); // +1 to highlight first letter of variable and not the $
             }
         },
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,7 +139,10 @@ fn assign_var(vars: &mut Vec<Variable>, user_value: f64, user_repr: String) {
             repr: user_repr,
             value: user_value,
         };
+        
         vars.push(user_var);
+        vars.sort_by(|a, b| b.repr.len().cmp(&a.repr.len()));
+
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ fn main() -> ! {
 
         if input == "$" {
             for v in vars.iter() {
-                println!("[ {} => {} ]", v.repr.green().bold(), v.value.to_string().blue());
+                println!("[ {} => {} ]", v.repr.green().bold(), format!("{:.3}", v.value).blue());
             }
             // Add the line to the history
             editor.add_history_entry(input);

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,7 @@ fn main() -> ! {
 }
 
 /// Formats a printable string listing all the `Variables` in the given slice `vars`
-fn list_vars_command(vars: &[Variable]) -> String {
+fn format_vars(vars: &[Variable]) -> String {
     vars.iter()
         .map(|var| {
             format!(
@@ -147,7 +147,11 @@ fn assign_var(vars: &mut Vec<Variable>, repr: &str, value: f64) {
 fn handle_input(input: &str, vars: &mut Vec<Variable>) -> Result<String, CliError> {
     if input == "$" {
         // Variable list command
-        Ok(list_vars_command(vars))
+        if vars.is_empty() {
+            Ok("No vars".to_string())
+        } else {
+            Ok(format_vars(vars))
+        }
     } else if input.contains('=') {
         // Assign / Reassign variable command
         assign_var_command(input, vars)

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,6 +78,22 @@ fn list_vars_command(vars: &[Variable]) -> String {
         }).join("\n")
   }
 
+  fn assign_var(vars: &mut Vec<Variable>, user_value: f64, user_repr: String) {
+    // Search to see if given representation exists
+    let found_var = vars.iter_mut().find(|x| x.repr == user_repr);
+    if let Some(found_var) = found_var {
+        // Reassign
+        found_var.value = user_value;
+    } else {
+        // Assign
+        let user_var = Variable {
+            repr: user_repr,
+            value: user_value,
+        };
+        vars.push(user_var);
+    }
+  }
+
 fn handle_input (input: &str, vars: &mut Vec<Variable>) -> Result<String, Error> {
     if input == "$" {
         // Variable list command
@@ -114,18 +130,7 @@ fn handle_input (input: &str, vars: &mut Vec<Variable>) -> Result<String, Error>
                 format!("{:.3}", user_value).blue()
             );
 
-            let found_var = vars.iter_mut().find(|x| x.repr == user_repr);
-            if let Some(found_var) = found_var {
-                // Reassign
-                found_var.value = user_value;
-            } else {
-                // Assign
-                let user_var = Variable {
-                    repr: user_repr,
-                    value: user_value,
-                };
-                vars.push(user_var);
-            }
+            assign_var(vars, user_value, user_repr);
             
             Ok(assign_confirmation)
         }
@@ -136,7 +141,7 @@ fn handle_input (input: &str, vars: &mut Vec<Variable>) -> Result<String, Error>
             return Err(Error::Parsing(idx));
         }
         let (x, repr) = result?;
-        
+
         let formatted = stringify(&repr, color_cli);
         let eval_string = format!("[ {} ] => {}", formatted, format!("{:.3}", x).blue());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,10 +31,10 @@ fn main() -> ! {
     }
 
     let mut vars: Vec<Variable> = Vec::new();
-    let repr = "abc".to_string();
-    let value = 6.5;
-    let test_var = Variable {repr, value};
-    vars.push(test_var);
+    let ans_repr = "ans".to_string();
+    let ans_value = 0.0;
+    let ans_var = Variable {repr: ans_repr, value: ans_value};
+    vars.push(ans_var);
 
     loop {
         #[allow(clippy::single_match_else)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,7 @@ fn main() -> ! {
 
         match handle_input(&input, &mut vars) {
             Ok(formatted) => println!("{}", formatted),
-            Err(error) => handle_errors(error, input),
+            Err(error) => handle_errors(error, &input),
         }
         
     }
@@ -153,8 +153,8 @@ fn handle_input (input: &str, vars: &mut Vec<Variable>) -> Result<String, Error>
     }
 }
 
-fn handle_errors(e: Error, input: String) {
-    match e {
+fn handle_errors(error: Error, input: &str) {
+    match error {
         Error::Parsing(idx) => {
             let first = if idx > 0 {
                 utils::slice(&input, 0, (idx) as i64)

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,8 +76,17 @@ fn main() -> ! {
                     continue;
                 }
             };
-            let user_var = Variable {repr: user_repr, value: user_value};
-            vars.push(user_var);
+
+            let found_var = vars.iter_mut().find(|x| x.repr == user_repr);
+            if let Some(found_var) = found_var {
+                //Reassign
+                found_var.value = user_value;
+            }
+            else {
+                //Assign
+                let user_var = Variable {repr: user_repr, value: user_value};
+                vars.push(user_var);
+            }
 
             // Add the line to the history
             editor.add_history_entry(input);

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,14 +30,12 @@ fn main() -> ! {
         editor.load_history(path).ok();
     }
 
-    let mut vars: Vec<Variable> = Vec::new();
-    let ans_repr = "ans".to_string();
-    let ans_value = 0.0;
-    let ans_var = Variable {
-        repr: ans_repr,
-        value: ans_value,
-    };
-    vars.push(ans_var);
+    let mut vars = vec![
+        Variable {
+            repr: String::from("ans"),
+            value: 0.0
+        }
+    ];
 
     loop {
         #[allow(clippy::single_match_else)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,9 @@ fn main() -> ! {
             continue;
         }
 
+        // Add the line to the history
+        editor.add_history_entry(&input);
+
         if input == "$" {
             // Variable list command
             for v in vars.iter() {
@@ -62,8 +65,6 @@ fn main() -> ! {
                     format!("{:.3}", v.value).blue()
                 );
             }
-            // Add the line to the history
-            editor.add_history_entry(input);
             continue;
         }
 
@@ -112,8 +113,6 @@ fn main() -> ! {
                 vars.push(user_var);
             }
 
-            // Add the line to the history
-            editor.add_history_entry(input);
             continue;
         }
 
@@ -124,9 +123,6 @@ fn main() -> ! {
                 continue;
             }
         };
-
-        // Add the line to the history
-        editor.add_history_entry(input);
 
         let formatted = stringify(&repr, color_cli);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,7 +110,7 @@ fn assign_var_command(input: &str, vars: &mut Vec<Variable>) -> Result<String, C
 
     // Get printable confirmation string
     let conf_string = format!(
-        "[ ${} {} {} => {} ]",
+        "[ ${} {} {} ] => {}",
         user_repr.green().bold(),
         "=".cyan(),
         stringify(&repr, color_cli),

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,9 +155,6 @@ fn handle_errors(e: Error, input: String, offset: usize) {
         Error::Assignment => {
             println!("Couldn't assign to variable. Malformed assignment statement.")
         }
-        Error::AssignmentName => {//Unused at the moment, no restrictions on variable names
-            println!("Couldnt assign to variable. Invalid variable name.")
-        }
         Error::UnknownVariable(idx) => {
             let offset_idx = idx + offset + 1; //+1 to account for $ sign
             let first = if offset_idx > 0 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,20 +125,19 @@ fn assign_var_command(input: &str, vars: &mut Vec<Variable>) -> Result<String, C
 
 /// Searches `vars` for the given `user_repr` to find if a [Variable] exists, and either reassigns it to, or creates it with, the given `user_value`
 fn assign_var(vars: &mut Vec<Variable>, user_value: f64, user_repr: &str) {
-    // Search to see if given representation exists
-    let found_var = vars.iter_mut().find(|x| x.repr == user_repr);
-    if let Some(found_var) = found_var {
-        // Reassign
-        found_var.value = user_value;
-    } else {
-        // Assign
-        let user_var = Variable {
-            repr: user_repr.to_string(),
-            value: user_value,
-        };
-
-        vars.push(user_var);
-        vars.sort_by(|a, b| b.repr.len().cmp(&a.repr.len()));
+    let cmp = |var: &Variable| user_repr.len().cmp(&var.repr.len());
+    let search = vars.binary_search_by(cmp);
+    match search {
+        Ok(idx) => {
+            vars[idx].value = user_value;
+        }
+        Err(idx) => {
+            let var = Variable {
+                repr: user_repr.to_string(),
+                value: user_value,
+            };
+            vars.insert(idx, var);
+        }
     }
 }
 
@@ -156,7 +155,7 @@ fn handle_input(input: &str, vars: &mut Vec<Variable>) -> Result<String, CliErro
         // Evaluate as normal
         let result = doeval(input, vars);
         if let Err(Error::Parsing(idx)) = result {
-            return Err(Error::Parsing(idx).into())
+            return Err(Error::Parsing(idx).into());
         }
         let (x, repr) = result?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,10 +44,7 @@ fn main() -> ! {
         editor.load_history(path).ok();
     }
 
-    let mut vars = vec![Variable {
-        repr: String::from("ans"),
-        value: 0.0,
-    }];
+    let mut vars = vec![];
 
     loop {
         #[allow(clippy::single_match_else)]
@@ -167,7 +164,7 @@ fn handle_input(input: &str, vars: &mut Vec<Variable>) -> Result<String, CliErro
         let formatted = stringify(&repr, color_cli);
         let eval_string = format!("[ {} ] => {}", formatted, format!("{:.3}", x).blue());
 
-        vars[0].value = x; // Set ans to new value
+        assign_var(vars, x, "ans".to_string()); // Set ans to new value
 
         Ok(eval_string)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ fn main() -> ! {
             continue;
         }
 
-        if input == "$" {
+        if input == "$" {//Variable list command
             for v in vars.iter() {
                 println!("[ {} => {} ]", ("$".to_owned() + &v.repr).green().bold(), format!("{:.3}", v.value).blue());
             }
@@ -61,7 +61,7 @@ fn main() -> ! {
             continue;
         }
 
-        if input.contains("=") {
+        if input.contains("=") {//Variable assignment/reassignment
             let sides: Vec<&str> = input.split('=').collect();
             if sides.len() != 2 { //Multiple = signs
                 handle_errors(Error::Assignment, input, 0);

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,37 +81,7 @@ fn main() -> ! {
         let (x, repr) = match doeval(&input, &vars) {
             Ok((a, b)) => (a, b),
             Err(e) => {
-                match e {
-                    Error::Parsing(idx) => {
-                        let first = if idx > 0 {
-                            utils::slice(&input, 0, (idx) as i64)
-                        } else {
-                            "".to_string()
-                        };
-                        println!(
-                            "Couldn't parse the token at index [{}]\n{}{}{}\n{}{}",
-                            idx.to_string().red(),
-                            first,
-                            input.chars().nth(idx).unwrap().to_string().on_red().white(),
-                            utils::slice(&input, idx + 1, -0),
-                            "~".repeat(idx).red().bold(),
-                            "^".red()
-                        );
-                    }
-                    Error::Operand(kind) => {
-                        println!(
-                            "Couldn't evaluate. Operator [{}] requires an operand.",
-                            format!("{:?}", kind).green()
-                        );
-                    }
-                    Error::EmptyStack => {
-                        println!("Couldn't evalutate. Stack was empty?");
-                    }
-                    Error::MismatchingParens => {
-                        println!("Couldn't evaluate. Mismatched parens.");
-                    }
-                }
-
+                handle_errors(e, input, 0);
                 continue;
             }
         };
@@ -125,6 +95,39 @@ fn main() -> ! {
     }
 }
 
+fn handle_errors(e: Error, input: String, offset: usize) {
+    match e {
+        Error::Parsing(idx) => {
+            let offset_idx = idx + offset;
+            let first = if offset_idx > 0 {
+                utils::slice(&input, 0, (offset_idx) as i64)
+            } else {
+                "".to_string()
+            };
+            println!(
+                "Couldn't parse the token at index [{}]\n{}{}{}\n{}{}",
+                offset_idx.to_string().red(),
+                first,
+                input.chars().nth(offset_idx).unwrap().to_string().on_red().white(),
+                utils::slice(&input, offset_idx + 1, -0),
+                "~".repeat(offset_idx).red().bold(),
+                "^".red()
+            );
+        }
+        Error::Operand(kind) => {
+            println!(
+                "Couldn't evaluate. Operator [{}] requires an operand.",
+                format!("{:?}", kind).green()
+            );
+        }
+        Error::EmptyStack => {
+            println!("Couldn't evalutate. Stack was empty?");
+        }
+        Error::MismatchingParens => {
+            println!("Couldn't evaluate. Mismatched parens.");
+        }
+    }
+}
 fn color_cli(string: &str, token: &Token) -> ColoredString {
     match token {
         Token::Number { .. } => string.clear(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,23 +118,23 @@ fn assign_var_command(input: &str, vars: &mut Vec<Variable>) -> Result<String, C
         format!("{:.3}", user_value).blue()
     );
 
-    assign_var(vars, user_value, &user_repr);
+    assign_var(vars, &user_repr, user_value);
 
     Ok(conf_string)
 }
 
 /// Searches `vars` for the given `user_repr` to find if a [Variable] exists, and either reassigns it to, or creates it with, the given `user_value`
-fn assign_var(vars: &mut Vec<Variable>, user_value: f64, user_repr: &str) {
-    let cmp = |var: &Variable| user_repr.len().cmp(&var.repr.len());
+fn assign_var(vars: &mut Vec<Variable>, repr: &str, value: f64) {
+    let cmp = |var: &Variable| repr.len().cmp(&var.repr.len());
     let search = vars.binary_search_by(cmp);
     match search {
         Ok(idx) => {
-            vars[idx].value = user_value;
+            vars[idx].value = value;
         }
         Err(idx) => {
             let var = Variable {
-                repr: user_repr.to_string(),
-                value: user_value,
+                repr: repr.to_string(),
+                value,
             };
             vars.insert(idx, var);
         }
@@ -162,7 +162,7 @@ fn handle_input(input: &str, vars: &mut Vec<Variable>) -> Result<String, CliErro
         let formatted = stringify(&repr, color_cli);
         let eval_string = format!("[ {} ] => {}", formatted, format!("{:.3}", x).blue());
 
-        assign_var(vars, x, "ans"); // Set ans to new value
+        assign_var(vars, "ans", x); // Set ans to new value
 
         Ok(eval_string)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,7 @@ fn main() -> ! {
         }
 
         if input == "$" {
-            //Variable list command
+            // Variable list command
             for v in vars.iter() {
                 println!(
                     "[ {} => {} ]",
@@ -70,10 +70,10 @@ fn main() -> ! {
         }
 
         if input.contains("=") {
-            //Variable assignment/reassignment
+            // Variable assignment/reassignment
             let sides: Vec<&str> = input.split('=').collect();
             if sides.len() != 2 {
-                //Multiple = signs
+                // Multiple = signs
                 handle_errors(Error::Assignment, input, 0);
                 continue;
             } else if !sides[0].trim().starts_with("$") {
@@ -85,12 +85,12 @@ fn main() -> ! {
             let (user_value, repr) = match doeval(&sides[1], &vars) {
                 Ok((a, b)) => (a, b),
                 Err(e) => {
-                    handle_errors(e, input.clone(), sides[0].len() + 1); //+1 to account for equals sign when doing error highlighting
+                    handle_errors(e, input.clone(), sides[0].len() + 1); // +1 to account for equals sign when doing error highlighting
                     continue;
                 }
             };
 
-            //Print assignment confimation
+            // Print assignment confimation
             let formatted = stringify(&repr, color_cli);
             println!(
                 "[ {}{} {} {} => {} ]",
@@ -103,10 +103,10 @@ fn main() -> ! {
 
             let found_var = vars.iter_mut().find(|x| x.repr == user_repr);
             if let Some(found_var) = found_var {
-                //Reassign
+                // Reassign
                 found_var.value = user_value;
             } else {
-                //Assign
+                // Assign
                 let user_var = Variable {
                     repr: user_repr,
                     value: user_value,
@@ -139,7 +139,7 @@ fn main() -> ! {
 }
 
 fn handle_errors(e: Error, input: String, offset: usize) {
-    //Offset is added so that highlighting can be added to expressions that come after an '=' during assignment
+    // Offset is added so that highlighting can be added to expressions that come after an '=' during assignment
     match e {
         Error::Parsing(idx) => {
             let offset_idx = idx + offset;

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,7 +69,13 @@ fn main() -> ! {
             }// other error checking etc
             
             let user_repr: String = sides[0].trim().to_string();
-            let user_value = sides[1].trim().parse().unwrap();
+            let (user_value, _repr) = match doeval(&sides[1], &vars) {
+                Ok((a, b)) => (a, b),
+                Err(e) => {
+                    handle_errors(e, input.clone(), sides[0].len()+1);
+                    continue;
+                }
+            };
             let user_var = Variable {repr: user_repr, value: user_value};
             vars.push(user_var);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,10 @@ fn main() -> ! {
     let mut vars: Vec<Variable> = Vec::new();
     let ans_repr = "ans".to_string();
     let ans_value = 0.0;
-    let ans_var = Variable {repr: ans_repr, value: ans_value};
+    let ans_var = Variable {
+        repr: ans_repr,
+        value: ans_value,
+    };
     vars.push(ans_var);
 
     loop {
@@ -52,47 +55,62 @@ fn main() -> ! {
             continue;
         }
 
-        if input == "$" {//Variable list command
+        if input == "$" {
+            //Variable list command
             for v in vars.iter() {
-                println!("[ {} => {} ]", ("$".to_owned() + &v.repr).green().bold(), format!("{:.3}", v.value).blue());
+                println!(
+                    "[ {} => {} ]",
+                    ("$".to_owned() + &v.repr).green().bold(),
+                    format!("{:.3}", v.value).blue()
+                );
             }
             // Add the line to the history
             editor.add_history_entry(input);
             continue;
         }
 
-        if input.contains("=") {//Variable assignment/reassignment
+        if input.contains("=") {
+            //Variable assignment/reassignment
             let sides: Vec<&str> = input.split('=').collect();
-            if sides.len() != 2 { //Multiple = signs
+            if sides.len() != 2 {
+                //Multiple = signs
+                handle_errors(Error::Assignment, input, 0);
+                continue;
+            } else if !sides[0].trim().starts_with("$") {
                 handle_errors(Error::Assignment, input, 0);
                 continue;
             }
-            else if !sides[0].trim().starts_with("$") {
-                handle_errors(Error::Assignment, input, 0);
-                continue;
-            }
-            
+
             let user_repr: String = sides[0].trim()[1..].to_string();
             let (user_value, repr) = match doeval(&sides[1], &vars) {
                 Ok((a, b)) => (a, b),
                 Err(e) => {
-                    handle_errors(e, input.clone(), sides[0].len()+1);
+                    handle_errors(e, input.clone(), sides[0].len() + 1);
                     continue;
                 }
             };
 
             //Print assignment confimation
             let formatted = stringify(&repr, color_cli);
-            println!("[ {}{} {} {} => {} ]", "$".green(), user_repr.green(), "=".cyan(), formatted, format!("{:.3}", user_value).blue());
+            println!(
+                "[ {}{} {} {} => {} ]",
+                "$".green(),
+                user_repr.green(),
+                "=".cyan(),
+                formatted,
+                format!("{:.3}", user_value).blue()
+            );
 
             let found_var = vars.iter_mut().find(|x| x.repr == user_repr);
             if let Some(found_var) = found_var {
                 //Reassign
                 found_var.value = user_value;
-            }
-            else {
+            } else {
                 //Assign
-                let user_var = Variable {repr: user_repr, value: user_value};
+                let user_var = Variable {
+                    repr: user_repr,
+                    value: user_value,
+                };
                 vars.push(user_var);
             }
 
@@ -123,7 +141,7 @@ fn main() -> ! {
 fn handle_errors(e: Error, input: String, offset: usize) {
     //Offset is added so that highlighting can be added to expressions that come after an '=' during assignment
     match e {
-        Error::Parsing(idx) => {    
+        Error::Parsing(idx) => {
             let offset_idx = idx + offset;
             let first = if offset_idx > 0 {
                 utils::slice(&input, 0, (offset_idx) as i64)
@@ -134,7 +152,13 @@ fn handle_errors(e: Error, input: String, offset: usize) {
                 "Couldn't parse the token at index [{}]\n{}{}{}\n{}{}",
                 offset_idx.to_string().red(),
                 first,
-                input.chars().nth(offset_idx).unwrap().to_string().on_red().white(),
+                input
+                    .chars()
+                    .nth(offset_idx)
+                    .unwrap()
+                    .to_string()
+                    .on_red()
+                    .white(),
                 utils::slice(&input, offset_idx + 1, -0),
                 "~".repeat(offset_idx).red().bold(),
                 "^".red()
@@ -166,7 +190,13 @@ fn handle_errors(e: Error, input: String, offset: usize) {
                 "Unknown variable at index [{}]\n{}{}{}\n{}{}",
                 offset_idx.to_string().red(),
                 first,
-                input.chars().nth(offset_idx).unwrap().to_string().on_red().white(),
+                input
+                    .chars()
+                    .nth(offset_idx)
+                    .unwrap()
+                    .to_string()
+                    .on_red()
+                    .white(),
                 utils::slice(&input, offset_idx + 1, -0),
                 "~".repeat(offset_idx).red().bold(),
                 "^".red()
@@ -188,7 +218,7 @@ fn color_cli(string: &str, token: &Token) -> ColoredString {
         }
         Token::Paren { .. } => string.magenta(),
         Token::Constant { .. } => string.yellow(),
-        Token::Variable { .. } => string.green()
+        Token::Variable { .. } => string.green(),
     }
 }
 
@@ -201,7 +231,7 @@ where
     for (idx, token) in tokens.iter().enumerate() {
         let colored: T = colorize(&token.ideal_repr(), token);
         let append = match *token {
-            Token::Number { .. } | Token::Constant { .. } | Token::Variable { .. }=> {
+            Token::Number { .. } | Token::Constant { .. } | Token::Variable { .. } => {
                 let is_r_paren = matches!(
                     tokens.get(idx + 1),
                     Some(Token::Paren {
@@ -315,7 +345,14 @@ mod tests {
         clippy::clippy::too_many_lines
     )]
 
-    use crate::{lib::constants::*, lib::doeval, lib::errors::Error, lib::operators::*, lib::{tokens::*, variables::Variable}, stringify};
+    use crate::{
+        lib::constants::*,
+        lib::doeval,
+        lib::errors::Error,
+        lib::operators::*,
+        lib::{tokens::*, variables::Variable},
+        stringify,
+    };
 
     fn same(a: f64, b: f64) -> bool {
         (a - b).abs() < 0.000_001
@@ -326,12 +363,18 @@ mod tests {
         let mut test_vars: Vec<Variable> = Vec::new();
         let test_var_repr_a = "v".to_string();
         let test_var_value_a = 5.0;
-        let test_var_a = Variable {repr: test_var_repr_a, value: test_var_value_a};
+        let test_var_a = Variable {
+            repr: test_var_repr_a,
+            value: test_var_value_a,
+        };
         test_vars.push(test_var_a);
 
         let test_var_repr_b = "pi".to_string();
         let test_var_value_b = 7.0;
-        let test_var_b = Variable {repr: test_var_repr_b, value: test_var_value_b};
+        let test_var_b = Variable {
+            repr: test_var_repr_b,
+            value: test_var_value_b,
+        };
         test_vars.push(test_var_b);
 
         [
@@ -528,11 +571,9 @@ mod tests {
                 "$v",
                 "$v",
                 5.0,
-                vec![
-                    Token::Variable {
-                        inner: &test_vars[0]
-                    }
-                ]
+                vec![Token::Variable {
+                    inner: &test_vars[0],
+                }],
             ),
             (
                 "$v + 5",
@@ -540,31 +581,27 @@ mod tests {
                 10.0,
                 vec![
                     Token::Variable {
-                        inner: &test_vars[0]
+                        inner: &test_vars[0],
                     },
                     Token::Operator {
-                        kind: OperatorType::Add
+                        kind: OperatorType::Add,
                     },
-                    Token::Number {
-                        value: 5.0
-                    }
-                ]
+                    Token::Number { value: 5.0 },
+                ],
             ),
             (
                 "  5 +    $v    ",
                 "5 + $v",
                 10.0,
                 vec![
-                    Token::Number {
-                        value: 5.0
-                    },
+                    Token::Number { value: 5.0 },
                     Token::Operator {
-                        kind: OperatorType::Add
+                        kind: OperatorType::Add,
                     },
                     Token::Variable {
-                        inner: &test_vars[0]
+                        inner: &test_vars[0],
                     },
-                ]
+                ],
             ),
             (
                 "pi + $pi",
@@ -572,15 +609,15 @@ mod tests {
                 std::f64::consts::PI + 7.0,
                 vec![
                     Token::Constant {
-                        kind: ConstantType::PI
+                        kind: ConstantType::PI,
                     },
                     Token::Operator {
-                        kind: OperatorType::Add
+                        kind: OperatorType::Add,
                     },
                     Token::Variable {
-                        inner: &test_vars[1]
+                        inner: &test_vars[1],
                     },
-                ]
+                ],
             ),
         ]
         .iter()

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,7 +85,7 @@ fn main() -> ! {
             let (user_value, repr) = match doeval(&sides[1], &vars) {
                 Ok((a, b)) => (a, b),
                 Err(e) => {
-                    handle_errors(e, input.clone(), sides[0].len() + 1);
+                    handle_errors(e, input.clone(), sides[0].len() + 1); //+1 to account for equals sign when doing error highlighting
                     continue;
                 }
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,10 +136,9 @@ fn assign_var(vars: &mut Vec<Variable>, user_value: f64, user_repr: &str) {
             repr: user_repr.to_string(),
             value: user_value,
         };
-        
+
         vars.push(user_var);
         vars.sort_by(|a, b| b.repr.len().cmp(&a.repr.len()));
-
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,7 +101,8 @@ fn handle_input (input: &str, vars: &mut Vec<Variable>) -> Result<String, Error>
     } else if input.contains("=") {
             // Variable assignment/reassignment
             let mut sides: Vec<&str> = input.split('=').collect();
-            sides[0] = sides[0].trim();
+            sides[0] = sides[0].trim(); // Trim here to remove space between end of variable name and = sign
+            
             if sides.len() != 2 {
                 // Multiple = signs
                 return Err(Error::Assignment);

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,7 +156,7 @@ fn handle_input(input: &str, vars: &mut Vec<Variable>) -> Result<String, CliErro
         // Evaluate as normal
         let result = doeval(input, vars);
         if let Err(Error::Parsing(idx)) = result {
-            return Err(CliError::Library(Error::Parsing(idx)));
+            return Err(Error::Parsing(idx).into())
         }
         let (x, repr) = result?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ use itertools::{self, Itertools};
 
 const HISTORY_FILE: &str = "rustcalc-history.txt";
 
-/// Error type for errors stemming from cli code, which includes [Error]s thrown by the library
+/// Error type for errors stemming from cli code, which includes `Errors` thrown by the library
 enum CliError {
     Assignment,
     Library(Error),
@@ -72,7 +72,7 @@ fn main() -> ! {
     }
 }
 
-/// Formats a printable string listing all the [Variable]s in the given slice `vars`
+/// Formats a printable string listing all the `Variables` in the given slice `vars`
 fn list_vars_command(vars: &[Variable]) -> String {
     vars.iter()
         .map(|var| {
@@ -143,7 +143,7 @@ fn assign_var(vars: &mut Vec<Variable>, repr: &str, value: f64) {
 
 /// Interprets a given user `input` and executes the given command or evaluates the given expression.
 /// * `input` - The user submitted string to be interpreted
-/// * `vars` - The vector of [Variable]s the user has already entered / will add to
+/// * `vars` - The vector of `Variables` the user has already entered / will add to
 fn handle_input(input: &str, vars: &mut Vec<Variable>) -> Result<String, CliError> {
     if input == "$" {
         // Variable list command

--- a/src/main.rs
+++ b/src/main.rs
@@ -226,8 +226,8 @@ fn handle_errors(error: CliError, input: &str) {
             Error::UnknownVariable(idx) => {
                 println!(
                     "{}",
-                    make_highlighted_error("Unknown variable at index", input, idx + 1)
-                ); // +1 to highlight first letter of variable and not the $
+                    make_highlighted_error("Unknown variable at index", input, idx)
+                );
             }
         },
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 #![warn(clippy::pedantic, clippy::nursery)]
 #![allow(clippy::wildcard_imports)]
 
-use std::{fmt::Display, process};
+use std::{cmp::Ordering, fmt::Display, process};
 
 mod lib;
 
@@ -124,7 +124,14 @@ fn assign_var_command(input: &str, vars: &mut Vec<Variable>) -> Result<String, C
 
 /// Searches `vars` for the given `user_repr` to find if a [Variable] exists, and either reassigns it to, or creates it with, the given `user_value`
 fn assign_var(vars: &mut Vec<Variable>, repr: &str, value: f64) {
-    let cmp = |var: &Variable| repr.len().cmp(&var.repr.len());
+    let cmp = |var: &Variable| {
+        let cmp = repr.len().cmp(&var.repr.len());
+        if Ordering::Equal == cmp {
+            repr.cmp(&var.repr)
+        } else {
+            cmp
+        }
+    };
     let search = vars.binary_search_by(cmp);
     match search {
         Ok(idx) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,16 +100,17 @@ fn handle_input (input: &str, vars: &mut Vec<Variable>) -> Result<String, Error>
         Ok(list_vars_command(&vars))
     } else if input.contains("=") {
             // Variable assignment/reassignment
-            let sides: Vec<&str> = input.split('=').collect();
+            let mut sides: Vec<&str> = input.split('=').collect();
+            sides[0] = sides[0].trim();
             if sides.len() != 2 {
                 // Multiple = signs
                 return Err(Error::Assignment);
-            } else if !sides[0].trim().starts_with("$") {
+            } else if !sides[0].starts_with("$") {
                 // Assigning without using a $ prefix
                 return Err(Error::Assignment);
             }
-
-            let user_repr: String = sides[0].trim()[1..].to_string();
+            
+            let user_repr: String = sides[0][1..].to_string(); // Trim again to remove whitespace between end of variable name and = sign
 
             // Get value for variable
             let result = doeval(sides[1], vars);

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,10 +153,7 @@ fn handle_input(input: &str, vars: &mut Vec<Variable>) -> Result<String, CliErro
         Ok(list_vars_command(&vars))
     } else if input.contains('=') {
         // Assign / Reassign variable command
-        match assign_var_command(&input, vars) {
-            Ok(conf_str) => Ok(conf_str),
-            Err(error) => Err(error),
-        }
+        assign_var_command(&input, vars) 
     } else {
         // Evaluate as normal
         let result = doeval(&input, &vars);

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,6 +97,8 @@ fn main() -> ! {
 
         let formatted = stringify(&repr, color_cli);
 
+        vars[0].value = x; // Set ans to new value
+
         println!("[ {} ] => {}", formatted, format!("{:.3}", x).blue());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,7 +115,14 @@ fn assign_var_command(input: &str, vars: &mut Vec<Variable>) -> Result<String, C
     let (user_value, repr) = result?;
 
     // Get printable confirmation string
-    let conf_string = assign_var_conf_string(repr, &user_repr, user_value);
+    let conf_string = format!(
+        "[ {}{} {} {} => {} ]",
+        "$".green(),
+        user_repr.green(),
+        "=".cyan(),
+        stringify(&repr, color_cli),
+        format!("{:.3}", user_value).blue()
+    );
 
     assign_var(vars, user_value, user_repr);
 
@@ -137,21 +144,6 @@ fn assign_var(vars: &mut Vec<Variable>, user_value: f64, user_repr: String) {
         };
         vars.push(user_var);
     }
-}
-
-/// Formats a printable string detailing the variable assignment described by the given `user_repr` and user `user_value`,
-/// and how it was calculated with the Vector of [Token]s `token_repr`
-fn assign_var_conf_string(token_repr: Vec<Token>, user_repr: &String, user_value: f64) -> String {
-    // Format assignment confirmation
-    let formatted = stringify(&token_repr, color_cli);
-    format!(
-        "[ {}{} {} {} => {} ]",
-        "$".green(),
-        user_repr.green(),
-        "=".cyan(),
-        formatted,
-        format!("{:.3}", user_value).blue()
-    )
 }
 
 /// Interprets a given user `input` and executes the given command or evaluates the given expression.

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,23 +89,23 @@ fn list_vars_command(vars: &[Variable]) -> String {
 fn assign_var_command(input: &str, vars: &mut Vec<Variable>) -> Result<String, CliError> {
      // Variable assignment/reassignment
 
-     let mut sides: Vec<&str> = input.split('=').collect();
-     sides[0] = sides[0].trim(); // Trim here to remove space between end of variable name and = sign
+     let sides: Vec<&str> = input.split('=').collect();
+     let trimmed_left = sides[0].trim(); // Trim here to remove space between end of variable name and = sign
 
      if sides.len() != 2 {
          // Multiple = signs
          return Err(CliError::Assignment);
-     } else if !sides[0].starts_with('$') {
+     } else if !trimmed_left.starts_with('$') {
          // Assigning without using a $ prefix
          return Err(CliError::Assignment);
      }
 
-     let user_repr: String = sides[0][1..].to_string(); // Trim again to remove whitespace between end of variable name and = sign
+     let user_repr: String = trimmed_left[1..].to_string(); // Trim again to remove whitespace between end of variable name and = sign
 
      // Get value for variable
      let result = doeval(sides[1], vars);
      if let Err(Error::Parsing(idx)) = result {
-         return Err(CliError::Library(Error::Parsing(idx + sides[0].len() + 1)));
+         return Err(CliError::Library(Error::Parsing(idx + sides[0].len() + 1))); // Length of untrimmed lefthand side
          // Offset is added so that highlighting can be added to expressions that come after an '=' during assignment
      }
      let (user_value, repr) = result?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,13 +69,17 @@ fn main() -> ! {
             }// other error checking etc
             
             let user_repr: String = sides[0].trim().to_string();
-            let (user_value, _repr) = match doeval(&sides[1], &vars) {
+            let (user_value, repr) = match doeval(&sides[1], &vars) {
                 Ok((a, b)) => (a, b),
                 Err(e) => {
                     handle_errors(e, input.clone(), sides[0].len()+1);
                     continue;
                 }
             };
+
+            //Print assignment confimation
+            let formatted = stringify(&repr, color_cli);
+            println!("[ {} {} {} => {} ]",user_repr.green(), "=".cyan(), formatted, format!("{:.3}", user_value).blue());
 
             let found_var = vars.iter_mut().find(|x| x.repr == user_repr);
             if let Some(found_var) = found_var {

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,6 +165,24 @@ fn handle_input(input: &str, vars: &mut Vec<Variable>) -> Result<String, CliErro
     }
 }
 
+fn make_highlighted_error(msg: &str, input_str: &str,  idx:usize) -> String{
+    let first = if idx > 0 {
+        utils::slice(&input_str, 0, (idx) as i64)
+    } else {
+        "".to_string()
+    };
+    format!(
+        "{} [{}]\n{}{}{}\n{}{}",
+        msg,
+        idx.to_string().red(),
+        first,
+        input_str.chars().nth(idx).unwrap().to_string().on_red().white(),
+        utils::slice(&input_str, idx + 1, -0),
+        "~".repeat(idx).red().bold(),
+        "^".red()
+    )
+}
+
 fn handle_errors(error: CliError, input: &str) {
     match error {
         CliError::Assignment => {
@@ -172,20 +190,7 @@ fn handle_errors(error: CliError, input: &str) {
         }
         CliError::Library(inner) => match inner {
             Error::Parsing(idx) => {
-                let first = if idx > 0 {
-                    utils::slice(&input, 0, (idx) as i64)
-                } else {
-                    "".to_string()
-                };
-                println!(
-                    "Couldn't parse the token at index [{}]\n{}{}{}\n{}{}",
-                    idx.to_string().red(),
-                    first,
-                    input.chars().nth(idx).unwrap().to_string().on_red().white(),
-                    utils::slice(&input, idx + 1, -0),
-                    "~".repeat(idx).red().bold(),
-                    "^".red()
-                );
+                println!("{}", make_highlighted_error("Couldn't parse the token at index", input, idx));
             }
             Error::Operand(kind) => {
                 println!(
@@ -200,20 +205,7 @@ fn handle_errors(error: CliError, input: &str) {
                 println!("Couldn't evaluate. Mismatched parens.");
             }
             Error::UnknownVariable(idx) => {
-                let first = if idx > 0 {
-                    utils::slice(&input, 0, (idx) as i64)
-                } else {
-                    "".to_string()
-                };
-                println!(
-                    "Unknown variable at index [{}]\n{}{}{}\n{}{}",
-                    idx.to_string().red(),
-                    first,
-                    input.chars().nth(idx).unwrap().to_string().on_red().white(),
-                    utils::slice(&input, idx + 1, -0),
-                    "~".repeat(idx).red().bold(),
-                    "^".red()
-                );
+                println!("{}", make_highlighted_error("Unknown variable at index", input, idx+1)); // +1 to highlight first letter of variable and not the $
             }
         },
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,6 +61,23 @@ fn main() -> ! {
             continue;
         }
 
+        if input.contains("=") {
+            let sides: Vec<&str> = input.split('=').collect();
+            if sides.len() != 2 {
+                //Error!
+                continue;
+            }// other error checking etc
+            
+            let user_repr: String = sides[0].trim().to_string();
+            let user_value = sides[1].trim().parse().unwrap();
+            let user_var = Variable {repr: user_repr, value: user_value};
+            vars.push(user_var);
+
+            // Add the line to the history
+            editor.add_history_entry(input);
+            continue;
+        }
+
         let (x, repr) = match doeval(&input, &vars) {
             Ok((a, b)) => (a, b),
             Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ use itertools::{self, Itertools};
 
 const HISTORY_FILE: &str = "rustcalc-history.txt";
 
+/// Error type for errors stemming from cli code, which includes [Error]s thrown by the library
 enum CliError {
     Assignment,
     Library(Error),
@@ -74,6 +75,7 @@ fn main() -> ! {
     }
 }
 
+/// Formats a printable string listing all the [Variable]s in the given slice `vars`
 fn list_vars_command(vars: &[Variable]) -> String {
     vars.iter()
         .map(|var| {
@@ -86,6 +88,7 @@ fn list_vars_command(vars: &[Variable]) -> String {
         .join("\n")
 }
 
+/// Takes the given user `input` and splits it up into a name and value to be assigned or reassigned to a [Variable] in `vars`
 fn assign_var_command(input: &str, vars: &mut Vec<Variable>) -> Result<String, CliError> {
     // Variable assignment/reassignment
 
@@ -119,6 +122,7 @@ fn assign_var_command(input: &str, vars: &mut Vec<Variable>) -> Result<String, C
     Ok(conf_string)
 }
 
+/// Searches `vars` for the given `user_repr` to find if a [Variable] exists, and either reassigns it to, or creates it with, the given `user_value`
 fn assign_var(vars: &mut Vec<Variable>, user_value: f64, user_repr: String) {
     // Search to see if given representation exists
     let found_var = vars.iter_mut().find(|x| x.repr == user_repr);
@@ -135,6 +139,8 @@ fn assign_var(vars: &mut Vec<Variable>, user_value: f64, user_repr: String) {
     }
 }
 
+/// Formats a printable string detailing the variable assignment described by the given `user_repr` and user `user_value`,
+/// and how it was calculated with the Vector of [Token]s `token_repr`
 fn assign_var_conf_string(token_repr: Vec<Token>, user_repr: &String, user_value: f64) -> String {
     // Format assignment confirmation
     let formatted = stringify(&token_repr, color_cli);
@@ -148,6 +154,9 @@ fn assign_var_conf_string(token_repr: Vec<Token>, user_repr: &String, user_value
     )
 }
 
+/// Interprets a given user `input` and executes the given command or evaluates the given expression.
+/// * `input` - The user submitted string to be interpreted
+/// * `vars` - The vector of [Variable]s the user has already entered / will add to
 fn handle_input(input: &str, vars: &mut Vec<Variable>) -> Result<String, CliError> {
     if input == "$" {
         // Variable list command
@@ -172,6 +181,7 @@ fn handle_input(input: &str, vars: &mut Vec<Variable>) -> Result<String, CliErro
     }
 }
 
+/// Makes a highlighted error message for use with [Error::Parsing] and [Error::UnknownVariable]
 fn make_highlighted_error(msg: &str, input_str: &str, idx: usize) -> String {
     let first = if idx > 0 {
         utils::slice(&input_str, 0, (idx) as i64)
@@ -196,6 +206,7 @@ fn make_highlighted_error(msg: &str, input_str: &str, idx: usize) -> String {
     )
 }
 
+/// Prints error messages for the given [CliError], referencing the `input` that caused them for clarity
 fn handle_errors(error: CliError, input: &str) {
     match error {
         CliError::Assignment => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 #![warn(clippy::pedantic, clippy::nursery)]
 #![allow(clippy::wildcard_imports)]
 
-use std::{cmp::Ordering, fmt::Display, process};
+use std::{fmt::Display, process};
 
 mod lib;
 
@@ -124,14 +124,7 @@ fn assign_var_command(input: &str, vars: &mut Vec<Variable>) -> Result<String, C
 
 /// Searches `vars` for the given `user_repr` to find if a [Variable] exists, and either reassigns it to, or creates it with, the given `user_value`
 fn assign_var(vars: &mut Vec<Variable>, repr: &str, value: f64) {
-    let cmp = |var: &Variable| {
-        let cmp = repr.len().cmp(&var.repr.len());
-        if Ordering::Equal == cmp {
-            repr.cmp(&var.repr)
-        } else {
-            cmp
-        }
-    };
+    let cmp = |var: &Variable| repr.cmp(&var.repr);
     let search = vars.binary_search_by(cmp);
     match search {
         Ok(idx) => {


### PR DESCRIPTION
I added functionality to allow for user defined variables, accessible by prefixing with a $
This includes
- Recalling the previous evaluated answer using `$ans`.
- Assigning any value (including the result of a expression) to a variable with an arbitrary name given by the user.
        -  e.g. `>$num = 5` and recalling with `2 + $num + 3`
- Reassigning the value of a variable using the same syntax.